### PR TITLE
Build/test with VS2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,14 +1,24 @@
+strategy:
+  matrix:
+    vs2017:
+      imageName: 'vs2017-win2016'
+      generator: 'Visual Studio 15 2017 Win64'
+    vs2019:
+      imageName: 'windows-2019'
+      generator: 'Visual Studio 16 2019'
+
+
 variables:
   BuildType: Debug
 
 pool:
-  vmImage: 'vs2017-win2016'
+  vmImage: $(imageName)
 
 steps:
 - task: CMake@1
   displayName: 'Configure'
   inputs:
-    cmakeArgs: '.. -G"Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=$(BuildType)'
+    cmakeArgs: '.. -G "$(generator)" -DCMAKE_BUILD_TYPE=$(BuildType)'
 - task: MSBuild@1
   displayName: 'Build'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,8 +24,14 @@ steps:
   inputs:
     cmakeArgs: '--build . --config $(BuildType)'
 - script: |
-        ctest --output-on-failure -C $(BuildType) --timeout 30
+        ctest --output-on-failure -C $(BuildType) --timeout 30 -T test
 
   workingDirectory: build
-  failOnStderr: true
+  continueOnError: true
   displayName: 'Test'
+- task: PublishTestResults@2
+  displayName: 'Publish Test Results'
+  inputs:
+    testResultsFormat: 'cTest'
+    testResultsFiles: 'build/Testing/**/Test.xml'
+    failTaskOnFailedTests: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,12 +18,11 @@ steps:
 - task: CMake@1
   displayName: 'Configure'
   inputs:
-    cmakeArgs: '.. -G "$(generator)" -DCMAKE_BUILD_TYPE=$(BuildType)'
-- task: MSBuild@1
+    cmakeArgs: '.. -G "$(generator)"'
+- task: CMake@1
   displayName: 'Build'
   inputs:
-    solution: build/win_handle_getter.sln
-    msbuildArguments: '/m /p:Configuration=$(BuildType)'
+    cmakeArgs: '--build . --config $(BuildType)'
 - script: |
         ctest --output-on-failure -C $(BuildType) --timeout 30
 

--- a/win_handle_getter/win_handle_getter.cpp
+++ b/win_handle_getter/win_handle_getter.cpp
@@ -5,6 +5,7 @@
 #include <ProcessSnapshot.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <vector>


### PR DESCRIPTION
Additionally does some general cleanup for the pipelines, including using `cmake --build` and publishing test results to the Azure GUI.